### PR TITLE
Allow settings to be read from environment variables

### DIFF
--- a/src/gateways/PxPay.php
+++ b/src/gateways/PxPay.php
@@ -80,9 +80,9 @@ class PxPay extends OffsiteGateway
     {
         /** @var Gateway $gateway */
         $gateway = Omnipay::create($this->getGatewayClassName());
-        $gateway->setUsername($this->username);
-        $gateway->setPassword($this->password);
-        $gateway->setTestMode($this->testMode);
+        $gateway->setUsername(Craft::parseEnv($this->username));
+        $gateway->setPassword(Craft::parseEnv($this->password));
+        $gateway->setTestMode(Craft::parseEnv($this->testMode));
         return $gateway;
     }
 

--- a/src/templates/gatewaySettings.html
+++ b/src/templates/gatewaySettings.html
@@ -1,22 +1,24 @@
-{% from "_includes/forms" import textField, lightswitchField, selectField %}
+{% from "_includes/forms" import autosuggestField, lightswitchField %}
 
 <div class="field"><p class="warning">This Gateway (PxPay) currently only supports the Credit Card Payment Type "Purchase".</p></div>
 
-{{ textField({
+{{ autosuggestField({
      label: "Username"|t('commerce'),
      id: 'username',
      class: 'ltr',
      name: 'username',
      value: gateway.username,
+     suggestEnvVars: true,
      errors: gateway.getErrors('username')
  }) }}
 
-  {{ textField({
+  {{ autosuggestField({
      label: "Password"|t('commerce'),
      id: 'password',
      class: 'ltr',
      name: 'password',
      value: gateway.password,
+     suggestEnvVars: true,
      errors: gateway.getErrors('password')
  }) }}
 


### PR DESCRIPTION
This plugin currently saves the `username` and `password` fields into the [project config file](https://docs.craftcms.com/v3/project-config.html) as text. This can be avoided if the settings are changed to [environmental settings](https://docs.craftcms.com/v3/extend/environmental-settings.html), which is what this pull request achieves.